### PR TITLE
Set correct unix file type in external attributes

### DIFF
--- a/lib/archivers/zip/constants.js
+++ b/lib/archivers/zip/constants.js
@@ -52,6 +52,7 @@ module.exports = {
   EXT_FILE_ATTR_FILE: 020151000040, // 644 -rw-r--r-- = (((S_IFREG | 0644) << 16) | S_DOS_A) >>> 0
 
   // Unix file types
+  S_IFMT: 0170000, /* type of file mask */  
   S_IFIFO: 010000, // named pipe (fifo)
   S_IFCHR: 020000, // character special
   S_IFDIR: 040000, // directory

--- a/lib/archivers/zip/constants.js
+++ b/lib/archivers/zip/constants.js
@@ -52,7 +52,7 @@ module.exports = {
   EXT_FILE_ATTR_FILE: 020151000040, // 644 -rw-r--r-- = (((S_IFREG | 0644) << 16) | S_DOS_A) >>> 0
 
   // Unix file types
-  S_IFMT: 0170000, /* type of file mask */  
+  S_IFMT: 0170000, // type of file mask  
   S_IFIFO: 010000, // named pipe (fifo)
   S_IFCHR: 020000, // character special
   S_IFDIR: 040000, // directory

--- a/lib/archivers/zip/zip-archive-entry.js
+++ b/lib/archivers/zip/zip-archive-entry.js
@@ -199,14 +199,10 @@ ZipArchiveEntry.prototype.setTime = function(time) {
 };
 
 ZipArchiveEntry.prototype.setUnixMode = function(mode) {
-  mode &= ~constants.S_IFDIR;
+  mode &= ~constants.S_IFMT;
+  mode |= this.isDirectory() ? constants.S_IFDIR : constants.S_IFREG;
+
   var extattr = 0;
-
-  if (!this.isDirectory()) {
-    mode |= constants.S_IFREG;
-  }
-
-  extattr &= ~this.getExternalAttributes();
   extattr |= (mode << constants.SHORT_SHIFT) | (this.isDirectory() ? constants.S_DOS_D : constants.S_DOS_A);
 
   this.setExternalAttributes(extattr);

--- a/test/zip-archive-entry.js
+++ b/test/zip-archive-entry.js
@@ -132,6 +132,17 @@ describe('ZipArchiveEntry', function() {
       entry.platform = 3;
       assert.equal(entry.getUnixMode(), 0777);
     });
+
+    it('should set proper external attributes for an unix directory', function () {
+      entry = new ZipArchiveEntry('directory/');
+      entry.setUnixMode(0777);
+
+      assert.ok(entry.getPlatform(), 3);
+      assert.ok(entry.isDirectory());
+
+      var exattr = entry.getExternalAttributes() >> 16;
+      assert.equal(exattr & 040000, 040000);
+    });
   });
 
   describe('#getVersionNeededToExtract', function() {
@@ -263,5 +274,4 @@ describe('ZipArchiveEntry', function() {
       assert.ok(entry.isDirectory());
     });
   });
-
 });


### PR DESCRIPTION
If a folder is compressed with e.g. grunt-contrib-compress it can be unzipped without any problems, but if the zip archive is inspected with "zipinfo -v" you will see this output:

Unix file attributes (000755 octal):              ?rwxr-xr-x
MS-DOS file attributes (10 hex):                  dir

which means that the unix file mode has been set correctly but the unix file type could not be determined, despite the MS-DOS file attributes have been set correctly. The issue is, that the unix file type information are currently not set, if the entry type is a directory.